### PR TITLE
Fix braces in appsettings

### DIFF
--- a/Schuler_Lehrer/C#/Uebung_Schueler_Lehrer/Uebung_Schueler_Lehrer/appsettings.json
+++ b/Schuler_Lehrer/C#/Uebung_Schueler_Lehrer/Uebung_Schueler_Lehrer/appsettings.json
@@ -6,10 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  {
-    "ConnectionStrings": {
-      "DefaultConnection":  "Server = localhost; Database = SchoolDb; Trusted_Connection = true;"
-    }
+  "ConnectionStrings": {
+    "DefaultConnection":  "Server = localhost; Database = SchoolDb; Trusted_Connection = true;"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
You had a mistake in your *appsettings.json* file: Too many curly braces. The error message *"An error occurred while accessing the Microsoft.Extensions.Hosting services. Continuing without the application service provider. Error: **Could not parse the JSON file**"* was an indicator.

Hope that helps.

Greetings,
Rainer Stropek.